### PR TITLE
Fixed duplicate script listing and add source line and some more small changes

### DIFF
--- a/css/debug-bar-list-deps.css
+++ b/css/debug-bar-list-deps.css
@@ -1,32 +1,60 @@
-.deps-table table{
+table.deps-table {
 	margin-top: .5rem;
 	width: 100%;
-	margin-bottom: -8px;
+	margin-bottom: 15px;
 	clear: both;
 	font-family: 'Helvetica Neue',sans-serif;
 	color: #000;
 	line-height: 150%!important;
 	text-align: left;
 	font-size: 12px!important;
+	border: 0 none;
+	border-bottom: 1px solid #666;
 }
 .deps-table tr {
 	display: table-row;
 	vertical-align: inherit;
 	border-color: inherit;
+	border: 0 none;
 }
 
-.deps-table th {
+.deps-table thead th {
+    padding: 0.7em 10px;
+    border-bottom: 1px solid #ccc;
+    width: auto;
 	vertical-align: top;
 	text-align: inherit;
-	padding: 10px;
+    background-color: #E8E8E8;
 }
 
 .deps-table td {
 	text-align: left;
 	margin-bottom: 9px;
-	padding: 8px 10px;
-	line-height: 20px;
+	padding: 8px 10px 0px 10px;
+	line-height: 16px;
 	font-size: 12px!important;
 	display: table-cell;
+	border: 0 none;
 }
 
+.deps-table tr.src td {
+	line-height: 100%;
+	padding: 4px 10px 8px 10px;
+	color: #999;
+	font-size: 85% !important;
+}
+
+.deps-table tr td:nth-child(2) {
+	width: 50%;
+}
+.deps-table tr td:nth-child(3) {
+	width: 45%;
+}
+.deps-table tr:nth-child(4n+1),
+.deps-table tr:nth-child(4n+2) {
+    background-color: #fff;
+}
+.deps-table tr:nth-child(4n+3),
+.deps-table tr:nth-child(4n+4) {
+    background-color: #eee;
+}

--- a/debug-bar-list-dependencies.php
+++ b/debug-bar-list-dependencies.php
@@ -27,28 +27,55 @@ function ps_listdeps_debug_bar_panels( $a ) {
 				global $wp_scripts, $wp_styles;
 
 ?>
-			<div class="xx">
-				<table width="100%" cellspacing="2" cellpadding="5" class="deps-table">
-					<tr><th colspan="3" style="font-size: 1.5rem;font-weight: bold">Enqueued Scripts</th></tr>
-					<tr><td>Order</td><td><b>Loaded</b></td><td><b>Dependencies</b></td></tr>
+			<div class="debug-bar-list-dependencies">
+				<h2>Enqueued Scripts</h2>
+				<table class="debug-bar-table deps-table">
+					<thead>
+						<tr><th>Order</th><th>Loaded</th><th>Dependencies</th></tr>
+					</thead>
+					<tbody>
 					<?php
-				$i = 1;				
-				foreach ( array_merge($wp_scripts->done, $wp_scripts->in_footer) as $loaded_scripts) {
+				$i = 1;
+				$loaded_scripts = array_merge($wp_scripts->done, $wp_scripts->in_footer);
+				$loaded_scripts = array_unique($loaded_scripts);
 
-					echo '<tr style="background-color:',  ( $i % 2 === 0 ) ? '#eee' : '#fff' , '"><td>', $i, '<td>', $loaded_scripts,  /*'<br/>',$wp_scripts->registered[$loaded_scripts]->src,*/ '</td><td>', ( count( $wp_scripts->registered[$loaded_scripts]->deps ) > 0 ) ?  join(' and ', array_filter(array_merge(array(join(', ', array_slice($wp_scripts->registered[$loaded_scripts]->deps, 0, -1))), array_slice($wp_scripts->registered[$loaded_scripts]->deps, -1)))) : '', '</td></tr>', "\n";
+				foreach ( $loaded_scripts as $loaded_script) {
+
+					echo '<tr><td>', $i, '<td>',
+						$loaded_script,
+						'</td><td>',
+						( count( $wp_scripts->registered[$loaded_script]->deps ) > 0 ) ?  join(' and ', array_filter(array_merge(array(join(', ', array_slice($wp_scripts->registered[$loaded_script]->deps, 0, -1))), array_slice($wp_scripts->registered[$loaded_script]->deps, -1)))) : '&nbsp;',
+						'</td></tr>',
+						'<tr class="src"><td>&nbsp;</td><td colspan="2">',
+						$wp_scripts->registered[$loaded_script]->src,
+						'</td></tr>', "\n";
 					$i++;
 				}
 ?>
-					<tr><th colspan="3" style="font-size: 1.5rem;font-weight: bold">Enqueued Styles</th></tr>
-					<tr><td>Order</td><td><b>Loaded</b></td><td><b>Dependencies</b></td></tr>
+					</tbody>
+  				</table>
+  				<h2>Enqueued Styles</h2>
+				<table class="debug-bar-table deps-table">
+					<thead>
+						<tr><th>Order</th><th>Loaded</th><th>Dependencies</th></tr>
+					</thead>
+					<tbody>
 					<?php
 
 				$i = 1;
 				foreach ( $wp_styles->done as $loaded_styles ) {
-					echo '<tr style="background-color:',  ( $i % 2 === 0 ) ? '#eee' : '#fff' , '"><td>', $i, '<td>', $loaded_styles, '</td><td>', ( count( $wp_styles->registered[$loaded_styles]->deps ) > 0 ) ?  join(' and ', array_filter(array_merge(array(join(', ', array_slice($wp_styles->registered[$loaded_styles]->deps, 0, -1))), array_slice($wp_styles->registered[$loaded_styles]->deps, -1)))) : '', '</td></tr>', "\n";
+					echo '<tr><td>', $i, '<td>',
+						$loaded_styles,
+						'</td><td>',
+						( count( $wp_styles->registered[$loaded_styles]->deps ) > 0 ) ?  join(' and ', array_filter(array_merge(array(join(', ', array_slice($wp_styles->registered[$loaded_styles]->deps, 0, -1))), array_slice($wp_styles->registered[$loaded_styles]->deps, -1)))) : '&nbsp;',
+						'</td></tr>',
+						'<tr class="src"><td>&nbsp;</td><td colspan="2">',
+						$wp_styles->registered[$loaded_styles]->src,
+						'</td></tr>', "\n";
 					$i++;
 				}
 ?>
+					</tbody>
 				</table>
 			</div>
 			<?php

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://soderlind.no/donate/
 Tags: debug, debug bar, development, wp_enqueue_script, wp_enqueue_style, script, styles, dependencies
 Requires at least: 3.4
 Tested up to: 3.5.1
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 
 Debug Bar List Script & Style Dependencies is an add-on to WordPress Debug Bar
@@ -54,7 +54,13 @@ Note, the front-end and back-end loads different scripts and styles. Also, diffe
 
 == Changelog ==
 
-= 1.0.2 = 
+= 1.0.3 =
+* (Partial) Bugfix for [Help tabs broken and missing scripts](https://github.com/soderlind/debug-bar-list-dependencies/issues/1)
+* Fix: duplicate script listings
+* New!: un-obtrusive script/style source line
+* Some other minor adjustments to compensate for the front-end themes
+
+= 1.0.2 =
 * Added styling
 = 1.0.1 =
 * Bugfix, fixed listing of styles and their dependencies


### PR DESCRIPTION
PHP:
- Fix: duplicate script listings
- Added: non-obtrusive script/style source line
- Small adjustments to the html to be inline with the general debug bar semantics and styling

CSS:
- Moved table row highlighting to CSS
- Some other minor adjustments to compensate for the twentythirteen theme screwing up the table display on the front-end

Readme:
- Update changelog
- Updated stable tag as otherwise (when added to the WP SVN) no upgrade will be offered
