### PR TITLE
Make loading of text-domain compatible with use of the plugin in the …

### DIFF
--- a/debug-bar-list-dependencies.php
+++ b/debug-bar-list-dependencies.php
@@ -23,7 +23,27 @@ function ps_listdeps_debug_bar_panels( $a ) {
 
 			function init() {
 				$this->enqueue();
-				load_plugin_textdomain( 'debug-bar-list-dependencies', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+				$this->load_textdomain( 'debug-bar-list-dependencies' );
+			}
+
+			/**
+			 * Load the plugin text strings.
+			 *
+			 * Compatible with use of the plugin in the must-use plugins directory.
+			 *
+			 * @param string $domain Text domain to load.
+			 */
+			protected function load_textdomain( $domain ) {
+				if ( is_textdomain_loaded( $domain ) ) {
+					return;
+				}
+
+				$lang_path = dirname( plugin_basename( __FILE__ ) ) . '/languages';
+				if ( false === strpos( __FILE__, basename( WPMU_PLUGIN_DIR ) ) ) {
+					load_plugin_textdomain( $domain, false, $lang_path );
+				} else {
+					load_muplugin_textdomain( $domain, $lang_path );
+				}
 			}
 
 			function enqueue() {

--- a/readme.txt
+++ b/readme.txt
@@ -59,6 +59,7 @@ Note, the front-end and back-end loads different scripts and styles. Also, diffe
 * Fix compatibility with the [Plugin Dependencies](http://wordpress.org/plugins/plugin-dependencies/) plugin
 * Fix weird table layout on front-end in combination with Twenty-Sixteen theme
 * Hard-code the text-domain for better compatibility with [GlotPress](https://translate.wordpress.org/projects/wp-plugins/debug-bar-list-dependencies).
+* Make loading of text-domain compatible with use of the plugin in the `must-use` plugins directory.
 
 = 1.0.6 =
 * Tested with WordPress 3.9. Bumped version number.


### PR DESCRIPTION
…`must-use` plugins directory.